### PR TITLE
updated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,19 @@ on:
 env:
   CI: true
 
-permissions: read-all
+permissions:
+  pull-requests: write
+  contents: write
+  packages: write
+  id-token: write
 
 jobs:
   version:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
@@ -23,20 +28,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Build Packages
-        run: pnpm run build
+        run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm ci:version
-          # publish: pnpm ci:publish
+          publish: pnpm ci:publish
           commit: "chore: update versions"
           title: "chore: update versions"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push tags after publish
+        if: steps.changesets.outputs.published == 'true'
+        run: git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - next
+
 env:
   CI: true
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-prefer-workspace-packages=true
-link-workspace-packages=true
-save-workspace-protocol=false # This prevents the examples to have the `workspace:` prefix

--- a/README.md
+++ b/README.md
@@ -121,10 +121,13 @@ In order to process this correctly perform the following steps:
 - Once the PR is merged into the baseBranch, a github action will publish packages automatically.
 
 - If you want to build and publish a pre-release version before going to the main branch, then rebase the "next" branch to the needed commit from main branch.
-  The github action will open a new PR with the "-next.0" tag. Once merged in the "next" branch it will publish the package(s) as described above.
+  The github action will open a new PR with the "-next.X" tag. Once merged in the "next" branch it will publish the package(s) as described above.
   For more informations and an example have a look at:
-- https://github.com/changesets/action/issues/69#issuecomment-774909280
-- https://github.com/statelyai/xstate/pull/902
+  - https://changesets-docs.vercel.app/en/prereleases
+  - https://github.com/changesets/action/issues/69#issuecomment-774909280
+  - https://github.com/statelyai/xstate/pull/902
+
+**Pay attention: never merge "next" branch into "main"!**
 
 ## Docker builds
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,15 @@ In order to process this correctly perform the following steps:
 
 - Commit the generated files that are inside `.changeset` folder
 
-- When the changesets files reach the "baseBranch" (actually "main"), a github action will generate a new PR with updated packages versions. Review the PR and approve merge.
+- When the changesets files reach the "baseBranch" (actually "main"), a github action will generate a new PR with updated packages versions. Review the PR and approve merge when ready to release a new version.
 
 - Once the PR is merged into the baseBranch, a github action will publish packages automatically.
+
+- If you want to build and publish a pre-release version before going to the main branch, then rebase the "next" branch to the needed commit from main branch.
+  The github action will open a new PR with the "-next.0" tag. Once merged in the "next" branch it will publish the package(s) as described above.
+  For more informations and an example have a look at:
+- https://github.com/changesets/action/issues/69#issuecomment-774909280
+- https://github.com/statelyai/xstate/pull/902
 
 ## Docker builds
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "turbo run dev",
     "lint": "eslint --fix",
     "ci:version": "pnpm changeset version && pnpm install",
-    "ci:publish": "pnpm build && pnpm changeset tag && pnpm publish -r --access public",
+    "ci:publish": "pnpm build && pnpm changeset tag && pnpm publish -r --no-git-checks --access public",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@italia/dati-semantic-schema-editor",
   "version": "0.0.7",
+  "private": true,
   "description": "",
   "main": "index.js",
   "keywords": [],
@@ -20,7 +21,7 @@
     "dev": "turbo run dev",
     "lint": "eslint --fix",
     "ci:version": "pnpm changeset version && pnpm install",
-    "ci:publish": "pnpm publish -r",
+    "ci:publish": "pnpm build && pnpm changeset tag && pnpm publish -r --access public",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+preferWorkspacePackages: true
+linkWorkspacePackages: true
+saveWorkspaceProtocol: false
 packages:
   - "apps/*"
   - "packages/*"


### PR DESCRIPTION
updated github workflow as the following:

- added correct permissions to workflow
- moved build command in order to be executed only in publish step
- added commands for the release step that performs build + tag + publish + push tags
- removed .npmrc in order to allow the bot to perform its operations and moved pnpm properties in proper file