### PR TITLE
Use `url` fragment instead of `?url` query parameter. See #82

### DIFF
--- a/apps/webapp/src/components/editor/editor.spec.tsx
+++ b/apps/webapp/src/components/editor/editor.spec.tsx
@@ -3,10 +3,12 @@ import { SchemaEditor } from '@teamdigitale/schema-editor';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 import * as configuration from '../../features/configuration';
+import * as navigation from '../../features/navigation';
 import { Editor } from './editor';
 
 describe('<Editor />', () => {
   let schemaEditorSpy: MockInstance<typeof SchemaEditor>;
+  let useNavigationSpy: MockInstance<typeof navigation.useNavigation>;
 
   beforeEach(() => {
     schemaEditorSpy = vi.spyOn(schemaEditor, 'SchemaEditor').mockReturnValue(<div>Test</div>);
@@ -14,6 +16,11 @@ describe('<Editor />', () => {
     vi.spyOn(configuration, 'useConfiguration').mockReturnValue({
       config: { oasCheckerUrl: 'https://test.com' },
       setConfig: () => ({}),
+    });
+
+    useNavigationSpy = vi.spyOn(navigation, 'useNavigation').mockReturnValue({
+      query: new URLSearchParams(),
+      hash: '',
     });
   });
 
@@ -24,42 +31,38 @@ describe('<Editor />', () => {
 
   it('should use the URL from hash fragment if present', async () => {
     const testUrl = 'https://example.com/schema.yaml';
-    const originalLocation = window.location;
-    window.location = { ...originalLocation, hash: `#url=${encodeURIComponent(testUrl)}` };
+    useNavigationSpy.mockReturnValue({
+      query: new URLSearchParams(),
+      hash: `url=${encodeURIComponent(testUrl)}`,
+    });
     render(<Editor />);
     expect(schemaEditorSpy).toHaveBeenCalledWith(
       { url: testUrl, spec: undefined, oasCheckerUrl: 'https://test.com' },
       {},
     );
-    window.location = originalLocation;
   });
 
   it('should use the OAS spec from hash if URL is not present', async () => {
-    const testFragment = '#oas:MYSwhg9gUEA';
-    const originalLocation = window.location;
-    window.location = {
-      ...originalLocation,
-      hash: testFragment,
-    };
+    useNavigationSpy.mockReturnValue({
+      query: new URLSearchParams(),
+      hash: 'oas:MYSwhg9gUEA',
+    });
     render(<Editor />);
     expect(schemaEditorSpy).toHaveBeenCalledWith(
       { url: undefined, spec: 'ciao\n', oasCheckerUrl: 'https://test.com' },
       {},
     );
-    window.location = originalLocation;
   });
 
   it('should default to the starter schema URL if no hash is present', async () => {
-    const originalLocation = window.location;
-    window.location = {
-      ...originalLocation,
+    useNavigationSpy.mockReturnValue({
+      query: new URLSearchParams(),
       hash: '',
-    };
+    });
     render(<Editor />);
     expect(schemaEditorSpy).toHaveBeenCalledWith(
       { url: 'schemas/starter-schema.oas3.yaml', spec: undefined, oasCheckerUrl: 'https://test.com' },
       {},
     );
-    window.location = originalLocation;
   });
 });

--- a/apps/webapp/src/features/navigation/hooks.ts
+++ b/apps/webapp/src/features/navigation/hooks.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export const useNavigation = () => {
+  const [query, setQuery] = useState<URLSearchParams>(() => new URLSearchParams(window.location.search));
+  const [hash, setHash] = useState<string>(() => window.location.hash.slice(1));
+
+  useEffect(() => {
+    const updateNavigation = () => {
+      setQuery(new URLSearchParams(window.location.search));
+      setHash(window.location.hash.slice(1));
+    };
+
+    window.addEventListener('popstate', updateNavigation);
+    window.addEventListener('hashchange', updateNavigation);
+
+    return () => {
+      window.removeEventListener('popstate', updateNavigation);
+      window.removeEventListener('hashchange', updateNavigation);
+    };
+  }, []);
+
+  return { query, hash };
+};

--- a/apps/webapp/src/features/navigation/index.ts
+++ b/apps/webapp/src/features/navigation/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -9,6 +9,11 @@ export default mergeConfig(
       clearMocks: true,
       environment: 'happy-dom',
       include: ['src/**/*.spec.{ts,tsx}'],
+      server: {
+        deps: {
+          inline: ['design-react-kit'],
+        },
+      },
     },
   }),
 );


### PR DESCRIPTION
## This PR

- use url fragment instead of query parameter
- ignores url query parameter
- shows a warning when url is used.