### PR TITLE
Fix: #30. Set semantic score initial value

### DIFF
--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-semantic-score.spec.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-semantic-score.spec.ts
@@ -132,6 +132,24 @@ describe('useSchemaSemanticScore', () => {
     });
   });
 
+  it('should return global semantic score from specJson if no calculation has been triggered yet', async () => {
+    const specJson = {
+      info: {
+        'x-semantic-score': 0.75,
+      },
+    };
+    const { result } = renderHook(() => useSchemaSemanticScore(specJson));
+    expect(result.current).toEqual({
+      status: 'idle',
+      error: undefined,
+      data: {
+        score: 0.75,
+        isUpdated: false,
+      },
+      recalculate: expect.any(Function),
+    });
+  });
+
   it('should return isUpdated false if spec is changed', async () => {
     vi.spyOn(utils, 'calculateSchemaSemanticScore').mockResolvedValue({
       schemaSemanticScore: 0.8,

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-semantic-score.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-semantic-score.ts
@@ -102,7 +102,7 @@ export function useSchemaSemanticScore(specJson: any): Omit<AsyncState<SchemaSem
     status: state.status,
     error: state.error,
     data: {
-      score: state.data?.score,
+      score: state.data?.score ?? specJson?.['info']?.['x-semantic-score'],
       isUpdated: !!lastHash && !!currentHash && lastHash === currentHash,
     },
     recalculate,


### PR DESCRIPTION
## This PR

- [x] updates global semantic score hook to show the x-semantic-score value as initial value if no calculation is triggered yet.
- [x] the "compute" button to be still grey, because the value shown is not computed by us 
- [x] recomputing does not change the editor value
