### PR TITLE
Fix: #85. Support owl:equivalentClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     ],
     "**/src/**/*.{json,js,ts,jsx,tsx}": [
       "prettier --write --ignore-unknown"
+    ],
+    "**/*": [
+      "pre-commit run --files"
     ]
   }
 }

--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-legend.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-legend.tsx
@@ -99,6 +99,14 @@ const LEGEND_ITEMS: LegendSection[] = [
           background: 'repeating-linear-gradient(to right, #9dbaea 0, #9dbaea 4px, transparent 4px, transparent 8px)',
         },
       },
+      {
+        label: 'Equivalent class',
+        indicator: {
+          width: '24px',
+          height: '3px',
+          backgroundColor: '#ff6b35',
+        },
+      },
     ],
   },
 ];

--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-schema.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-schema.tsx
@@ -19,7 +19,7 @@ export const GraphSchema = ({ specSelectors, editorActions }) => {
     [JSON.stringify(specSelectors?.spec().toJSON())],
   );
 
-  // Nodes from resolved superclasses
+  // Nodes from resolved superclasses and equivalent classes
   const [selectedClassUri, setSelectedClassUri] = useState<string | undefined>(undefined);
   const { data: superclassData = [], status: superclassStatus } = useRDFClassTreeResolver(selectedClassUri);
   const superclassNodes = useSuperclassDataToNodes(superclassData);
@@ -27,7 +27,7 @@ export const GraphSchema = ({ specSelectors, editorActions }) => {
   // Toggle superclasses visibility
   const [showSuperclasses, setShowSuperclasses] = useState(true);
 
-  // All nodes (merge both spec and superclass nodes)
+  // All nodes (merge spec, superclass, and equivalent class nodes)
   const allNodes = useMemo(
     () => [
       ...specNodes,
@@ -238,6 +238,15 @@ export const GraphSchema = ({ specSelectors, editorActions }) => {
               selector: 'edge[type="dashed"]',
               style: {
                 'line-style': 'dashed',
+                'target-arrow-shape': 'triangle',
+              },
+            },
+            {
+              selector: 'edge[type="equivalent"]',
+              style: {
+                label: 'equivalent to',
+                'line-style': 'dashed',
+                'source-arrow-shape': 'triangle',
                 'target-arrow-shape': 'triangle',
               },
             },

--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/oas-graph-hooks.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/oas-graph-hooks.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
+import { RDFClassTreeData } from '../../../hooks';
 import { GraphElement, insertSpaceInCamelCase } from './oas-graph';
 
-export function useSuperclassDataToNodes(superclassData: { parent: string; child: string }[]): GraphElement[] {
+export function useSuperclassDataToNodes(superclassData: RDFClassTreeData[]): GraphElement[] {
   const [allNodes, setAllNodes] = useState<GraphElement[]>([]); // Keeps older nodes too
 
   useEffect(() => {
@@ -11,7 +12,7 @@ export function useSuperclassDataToNodes(superclassData: { parent: string; child
 
     const newElements: GraphElement[] = [];
 
-    for (const { child, parent } of superclassData) {
+    for (const { child, parent, equivalent } of superclassData) {
       // Add child nodes
       if (child) {
         newElements.push({
@@ -28,13 +29,31 @@ export function useSuperclassDataToNodes(superclassData: { parent: string; child
           type: 'rdf',
         });
       }
-      // Add edges
+      // Add equivalent nodes
+      if (equivalent) {
+        // If this is an equivalentClass relationship, use 'equivalent' type, otherwise 'dashed' for subClassOf
+        newElements.push({
+          id: equivalent,
+          label: insertSpaceInCamelCase(equivalent.split('/').pop() ?? equivalent),
+          type: 'rdf',
+        });
+      }
+      // Add child-parent edges
       if (child && parent) {
         newElements.push({
           id: `${child}->${parent}`,
           source: child,
           target: parent,
           type: 'dashed',
+        });
+      }
+      // Add equivalent edges
+      if (child && equivalent) {
+        newElements.push({
+          id: `${child}->${equivalent}`,
+          source: child,
+          target: equivalent,
+          type: 'equivalent',
         });
       }
     }

--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/oas-graph.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/oas-graph.ts
@@ -11,7 +11,7 @@ export interface GraphEdge {
   id: string;
   source: string;
   target: string;
-  type: 'solid' | 'dashed';
+  type: 'solid' | 'dashed' | 'equivalent';
 }
 
 export type GraphElement = GraphNode | GraphEdge;

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
@@ -139,22 +139,27 @@ describe('useRDFClassTreeResolver', () => {
       {
         parent: 'https://w3id.org/italia/onto/l0/Entity',
         child: 'https://w3id.org/italia/onto/l0/Agent',
+        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Object',
         child: 'https://w3id.org/italia/onto/l0/Agent',
+        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Entity',
         child: 'https://w3id.org/italia/onto/l0/Object',
+        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/CPV/Person',
         child: 'https://w3id.org/italia/onto/CPV/Alive',
+        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Agent',
         child: 'https://w3id.org/italia/onto/CPV/Person',
+        equivalent: undefined,
       },
     ]);
   });
@@ -179,6 +184,33 @@ describe('useRDFClassTreeResolver', () => {
     const { result } = renderHook(() => useRDFClassTreeResolver('https://w3id.org/italia/onto/CPV/NonExistentClass'));
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
     expect(result.current.data).toEqual([]);
+  });
+
+  it('should resolve equivalent classes', async () => {
+    const mockResponse = {
+      results: {
+        bindings: [
+          {
+            parent: { type: 'uri', value: 'https://w3id.org/italia/onto/CPV/EquivalentClass' },
+            child: { type: 'uri', value: 'https://w3id.org/italia/onto/CPV/Person' },
+            equivalent: { type: 'uri', value: 'https://w3id.org/italia/onto/CPV/EquivalentClass' },
+          },
+        ],
+      },
+    };
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(mockResponse)));
+
+    const { result } = renderHook(() => useRDFClassTreeResolver('https://w3id.org/italia/onto/CPV/Person'));
+
+    await waitFor(() => expect(result.current.status).toBe('fulfilled'));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]).toEqual({
+      parent: 'https://w3id.org/italia/onto/CPV/EquivalentClass',
+      child: 'https://w3id.org/italia/onto/CPV/Person',
+      equivalent: 'https://w3id.org/italia/onto/CPV/EquivalentClass',
+    });
   });
 });
 

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
@@ -139,27 +139,22 @@ describe('useRDFClassTreeResolver', () => {
       {
         parent: 'https://w3id.org/italia/onto/l0/Entity',
         child: 'https://w3id.org/italia/onto/l0/Agent',
-        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Object',
         child: 'https://w3id.org/italia/onto/l0/Agent',
-        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Entity',
         child: 'https://w3id.org/italia/onto/l0/Object',
-        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/CPV/Person',
         child: 'https://w3id.org/italia/onto/CPV/Alive',
-        equivalent: undefined,
       },
       {
         parent: 'https://w3id.org/italia/onto/l0/Agent',
         child: 'https://w3id.org/italia/onto/CPV/Person',
-        equivalent: undefined,
       },
     ]);
   });

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.spec.ts
@@ -2,11 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as configuration from '../../configuration';
 import {
-  useRDFPropertyResolver,
-  useRDFClassTreeResolver,
-  useRDFClassResolver,
   useRDFClassPropertiesResolver,
+  useRDFClassResolver,
+  useRDFClassTreeResolver,
   useRDFClassVocabulariesResolver,
+  useRDFPropertyResolver,
 } from './use-rdf-ontologies-resolver';
 
 describe('useRDFPropertyResolver', () => {
@@ -194,7 +194,7 @@ describe('useRDFClassTreeResolver', () => {
       },
     };
 
-    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(mockResponse)));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify(mockResponse)));
 
     const { result } = renderHook(() => useRDFClassTreeResolver('https://w3id.org/italia/onto/CPV/Person'));
 

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
@@ -76,23 +76,40 @@ export function useRDFPropertyResolver(fieldUri: string | undefined): AsyncState
 }
 
 /*
-  This hook resolves the class hierarchy tree, returning parent-child relationships.
+  This hook resolves the class hierarchy tree, returning parent-child relationships and equivalent classes.
 */
-export function useRDFClassTreeResolver(classUri: string | undefined): AsyncState<{ parent: string; child: string }[]> {
+export interface RDFClassTreeData {
+  parent: string;
+  child: string;
+  equivalent?: string;
+}
+
+export function useRDFClassTreeResolver(classUri: string | undefined): AsyncState<RDFClassTreeData[]> {
   const { data, status, error } = useSparqlQuery(
     `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
     SELECT DISTINCT
       ?child
       ?parent
+      ?equivalent
     WHERE {
 
       <${classUri}> rdfs:subClassOf* ?child .
       ?child rdfs:subClassOf ?parent .
 
-      FILTER( !isBlank(?child) && !isBlank(?parent) && ?child != ?parent)
+      OPTIONAL {
+        ?child (owl:equivalentClass | ^owl:equivalentClass) ?equivalent .
+        FILTER(!isBlank(?equivalent))
+      }
+    
+      FILTER(
+        !isBlank(?child) &&
+        !isBlank(?parent) &&
+        ?child != ?parent
+      )
     }
   `,
     { skip: !classUri || !isUri(classUri) },

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
@@ -104,7 +104,7 @@ export function useRDFClassTreeResolver(classUri: string | undefined): AsyncStat
         ?child (owl:equivalentClass | ^owl:equivalentClass) ?equivalent .
         FILTER(!isBlank(?equivalent))
       }
-    
+
       FILTER(
         !isBlank(?child) &&
         !isBlank(?parent) &&


### PR DESCRIPTION
- Added equivalentClass balloon when resolving semantic tree in graph.
- SparQL query to retrieve equivalent class optionally


note to self: https://www.stelselcatalogus.nl/sparql