### PR TITLE
Fix: #130.  Avoid exposing internal details when a static resource is not found

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -36,10 +36,8 @@ import { SemanticScoreModule } from './features/semantic-score';
     }),
     HealthModule,
     ServeStaticModule.forRoot({
+      renderPath: 'openapi.yaml',
       rootPath: join(__dirname, '..', 'public'),
-      serveStaticOptions: {
-        fallthrough: false,
-      },
     }),
     SemanticScoreModule,
   ],


### PR DESCRIPTION
Updated API config to expose only one file as static asset.
Other resources will return simply 404