### PR TITLE
Open example button updated to open the url in a new tab

### DIFF
--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/example-accordion.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/example-accordion.tsx
@@ -43,6 +43,8 @@ export function ExampleAccordion({ depth, schema, jsonldContext, getConfigs }: P
               disabled={!jsonldPlaygroundUrl || !jsonldContext || !example}
               href={jsonldPlaygroundUrl + encodeURIComponent(JSON.stringify(jsonldExample, null, 2))}
               title="Open in playground"
+              /** @ts-expect-error missing target attribute in interface when rendering a button as a link */
+              target="_blank"
             >
               Open example
               <Icon icon="it-external-link" size="xs" color="primary" className="ms-2" />


### PR DESCRIPTION
Added target blank attribute to open the example in playground as a new tab