### PR TITLE
Fix: #141. Long names in root models truncated

### DIFF
--- a/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.tsx
@@ -26,7 +26,7 @@ export function ModelCollapseRoot({ title, specPath }: Props) {
       <Card className="card-bg" spacing>
         <CardBody>
           <h5 className="big-heading d-flex justify-content-between text-primary mb-0">
-            {title || 'Show'}
+            <span className="text-truncate">{title || 'Show'}</span>
             <Icon icon="it-chevron-right" color="primary" />
           </h5>
         </CardBody>


### PR DESCRIPTION
## This PR

- Fix: #141
- [x] Added text-truncate bootstrap class

## Notes

[See demo](https://teamdigitale.github.io/dati-semantic-schema-editor/stefanone91-141-bug-long-model-names-go-out-of-screen/#oas:MQKGAJPYIdQUwDYGMD2BbeBCMVwFEATASwBdxSALecAM1UUVQHdiA7Ac3AGdlr0AhuHgAPAegAOieN3DsKlYrO7xBbUsWTCSpVACdcUAEYCVhcKjbgAyswEcO8PQR36AdGBCoJ8NgInEAFzgAMxuAAxuISBokpa+pNyBIJC8-KbJeADyehxu+GKS0m4AwhhuALIAngAKAsgA1vbw+YQArsgCGpYAMvAAbki5+YVSLWXolbX1TY6tHV3EvQNImXgUVT7BqEYAVvDIpCASXZRJ4ADeAL4gKnqDeucA2gC6IKT2z2-s9GsapNJggBBHh8VRCNCMA7dNgpcAPbhLNjBABM4RRAEZwgAOCIYiLhOEiAC03Da6EEeiqwNB6XAkOkhyR4FYVHAJRqADULOoGKgOFUPJBEJpfCo1pA-JhgScwcSURE4ZA2npEMFKKRSBIkgB6HXeMWoFXIFr6Dg6kUmtgqbg6oGy6jyxWQUhOdDcLK0axOfqi9Wa7WBPUG61GvQmtxmi2i60yO0O+BOwmQNDqeqkCXgKXwYIAJR2Tl04BqDBFSuEgmIavAeh2xAkpeIAAEOJXEG5YuWVdWNVqgzruBJkIQugI3CQOGQTm4OKh+m4yHaKewlKQ9AIAF5I+A6+zEQhwwgyZB6esw4IAH2JIHLMHACBQGGw5aIZAUNHojBY7C4aXBwlGaRZHkKglB4cF1E0bQyH0csTDMHkbDsBwnBcGC9A8IA)