### PR TITLE
Fix: #178. Show semantic score tooltip on model border

### DIFF
--- a/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.scss
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.scss
@@ -2,19 +2,28 @@
   &.card-space {
     padding-bottom: 1.5rem;
   }
+  .card-bg {
+    position: relative;
+    .model-border {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 5px;
+      border-left: 5px solid transparent;
+      transition: border-color 0.3s ease;
 
-  .card {
-    border-left: 5px solid transparent;
-    transition: border-color 0.3s ease;
+      &.score-success {
+        border-left-color: var(--bs-success);
+      }
 
-    &.score-success {
-      border-left-color: var(--bs-success);
+      &.score-warning {
+        border-left-color: var(--bs-warning);
+      }
+      &.score-none {
+        border-left-color: var(--bs-gray-300);
+      }
     }
-
-    &.score-warning {
-      border-left-color: var(--bs-warning);
-    }
-
     &:after {
       content: unset;
     }

--- a/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/model-collapse-root.tsx
@@ -4,6 +4,7 @@ import { Card, CardBody, Icon } from 'design-react-kit';
 import { useSchemaNavigation } from '../../overview/components/Navigation';
 import { useSemanticScoreColor } from '../hooks';
 import { useGlobalSemanticScore } from './semantic-score';
+import { SemanticScoreTooltip } from './semantic-score-tooltip';
 
 interface Props {
   title: string;
@@ -28,11 +29,14 @@ export function ModelCollapseRoot({ title, specPath }: Props) {
   const modelScoreEntry = semanticData?.models.find((m) => m.name === name);
   const modelScore = modelScoreEntry?.score ?? 0;
   const semanticScoreColor = useSemanticScoreColor(modelScore);
-  const semanticScoreClass = modelScoreEntry ? `score-${semanticScoreColor}` : '';
+  const semanticScoreClass = modelScoreEntry ? `score-${semanticScoreColor}` : 'score-none';
+  const hasSemanticScore = !!modelScoreEntry;
+  const tooltipId = `model-card-tooltip-${specPathArray.join('-')}`;
 
   return (
     <a href="#" className="text-decoration-none" onClick={handleClick}>
-      <Card className={`card-bg ${semanticScoreClass}`} spacing>
+      <Card className="card-bg" spacing>
+        <div id={tooltipId} className={`model-border ${semanticScoreClass}`}></div>
         <CardBody>
           <h5 className="big-heading d-flex justify-content-between text-primary mb-0">
             {title || 'Show'}
@@ -40,6 +44,7 @@ export function ModelCollapseRoot({ title, specPath }: Props) {
           </h5>
         </CardBody>
       </Card>
+      <SemanticScoreTooltip targetId={tooltipId} score={modelScoreEntry?.score} />
     </a>
   );
 }

--- a/packages/schema-editor/src/plugins/json-schema-5/components/semantic-score-tooltip.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/semantic-score-tooltip.tsx
@@ -1,0 +1,28 @@
+import { UncontrolledTooltip } from 'design-react-kit';
+
+interface Props {
+  targetId: string;
+  score?: number;
+}
+
+export function SemanticScoreTooltip({ targetId, score }: Props) {
+  const hasScore = score !== undefined;
+
+  return (
+    <UncontrolledTooltip placement="top" target={targetId}>
+      {hasScore ? (
+        <>
+          <strong>Semantic score: {score}</strong>
+          <br />
+          Indicates the completeness of semantic annotations.
+        </>
+      ) : (
+        <>
+          <strong>Semantic score not available</strong>
+          <br />
+          Scores are calculated only for schema elements of type object.
+        </>
+      )}
+    </UncontrolledTooltip>
+  );
+}

--- a/packages/schema-editor/src/plugins/overview/components/Tabs/help.md
+++ b/packages/schema-editor/src/plugins/overview/components/Tabs/help.md
@@ -17,6 +17,9 @@ L'applicazione mostra:
   i vincoli legati alle classi semantiche
   ([`rdfs:Class`](https://www.w3.org/2000/01/rdf-schema#Class) / [`owl:Class`](https://www.w3.org/2002/07/owl#Class))
   e al dominio applicativo ([`rdfs:domain`](https://www.w3.org/2000/01/rdf-schema#domain), [`rdfs:range`](https://www.w3.org/2000/01/rdf-schema#range)).
+- un punteggio semantico (semantic score) che indica il livello di completezza
+  delle annotazioni semantiche presenti nello schema.
+  Il punteggio viene calcolato sulla base delle informazioni semantiche disponibili ed è visualizzato nell'interfaccia tramite apposita dicitura 'Schema Semantic Score' e tramite un indicatore laterale accanto agli elementi dello schema di tipo `object`. L'indicatore avrà colore verde nel caso di un punteggio sufficiente, giallo in caso contrario, grigio in caso di tipo non `object`.
 
 Puoi aprire uno schema OpenAPI in formato JSON o YAML:
 
@@ -57,6 +60,13 @@ The application shows:
   the title([`rdfs:label`](https://www.w3.org/2000/01/rdf-schema#label)),
   the constraints related to the semantic classes
   ( [`rdfs:Class`](https://www.w3.org/2000/01/rdf-schema#Class) / [`owl:Class`](https://www.w3.org/2002/07/owl#Class)) and to the application domain (`rdfs:domain`, `rdfs:range`).
+- a semantic score indicating the level of completeness
+  of the semantic annotations in the schema.
+  The score is calculated based on the available semantic metadata
+  (for example `rdfs:label`, `rdfs:comment`, `rdfs:domain`, `rdfs:range`, etc.)
+  and is displayed in the interface through the "Schema Semantic Score" label
+  and through a side indicator next to schema elements defined as `type: object`.
+  The indicator is green when the score is considered sufficient, yellow otherwise, grey if type is non-object.
 
 You can open an OpenAPI schema in JSON or YAML format:
 


### PR DESCRIPTION
- added a light grey color to items whose semantic score cannot be calculated due to invalid type (not object)