### PR TITLE
Fix: #80. Search schemas via SparQL endpoint

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,7 +1,8 @@
-import 'bootstrap-italia/dist/css/bootstrap-italia.min.css';
 import '@teamdigitale/schema-editor/dist/style.css';
+import 'bootstrap-italia/dist/css/bootstrap-italia.min.css';
 import { Editor } from './components/editor/editor';
 import { Layout } from './components/layout/layout';
+import { SearchSchemaModal } from './components/search-schema-modal/search-schema-modal';
 import { ConfigurationProvider } from './features/configuration';
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
     <ConfigurationProvider>
       <Layout>
         <Editor />
+        <SearchSchemaModal />
       </Layout>
     </ConfigurationProvider>
   );

--- a/apps/webapp/src/components/search-schema-modal/search-schema-modal.tsx
+++ b/apps/webapp/src/components/search-schema-modal/search-schema-modal.tsx
@@ -95,7 +95,7 @@ export function SearchSchemaModal() {
 
   // Select
   const handleSelectUrl = (url: string) => {
-    window.history.pushState({}, '', `#url=${url}`);
+    window.location.href = `#url=${encodeURIComponent(url)}`;
     setIsOpen(false);
   };
 

--- a/apps/webapp/src/components/search-schema-modal/search-schema-modal.tsx
+++ b/apps/webapp/src/components/search-schema-modal/search-schema-modal.tsx
@@ -1,0 +1,155 @@
+import { useSparqlQuery } from '@teamdigitale/schema-editor';
+import {
+  Alert,
+  Button,
+  ButtonGroup,
+  Form,
+  Icon,
+  InputGroup,
+  InputGroupText,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  Spinner,
+} from 'design-react-kit';
+import { useEffect, useMemo, useState } from 'react';
+import { useConfiguration } from '../../features/configuration';
+
+const SPARQL_QUERY = `
+prefix admsapit: <https://w3id.org/italia/onto/ADMS/>
+prefix COV: <https://w3id.org/italia/onto/COV/>
+prefix dcat: <http://www.w3.org/ns/dcat#>
+prefix dcatapit: <http://dati.gov.it/onto/dcatapit#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+select distinct ?label ?url where {
+  ?s
+    a dcatapit:Distribution ;
+    dcat:downloadURL ?url ;
+    rdfs:label ?label
+  .
+  FILTER(
+    STRSTARTS(
+      STR(?s),
+      "https://w3id.org/italia/schemas/"
+    )
+  )
+}
+`;
+
+export function SearchSchemaModal() {
+  const { config } = useConfiguration();
+
+  // Open and close
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'P') {
+        e.preventDefault();
+        setIsOpen(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  // Search
+  const [searchTerm, setSearchTerm] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchTerm('');
+    }
+  }, [isOpen]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    setSearchTerm(event.target[0].value);
+  };
+
+  const { status, data, error } = useSparqlQuery(SPARQL_QUERY, { sparqlUrl: config.sparqlUrl!, skip: !isOpen });
+  const schemas: { label: string; url: string }[] = useMemo(() => {
+    return (
+      data?.results?.bindings?.map((binding) => ({
+        label: binding.label.value,
+        url: binding.url.value,
+      })) || []
+    );
+  }, [data]);
+  const filteredSchemas = schemas?.filter(
+    (schema) =>
+      schema.label.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      schema.url.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  // Select
+  const handleSelectUrl = (url: string) => {
+    window.history.pushState({}, '', `#url=${url}`);
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={handleClose} size="lg" centered scrollable>
+      <ModalHeader toggle={handleClose}>Open Schema</ModalHeader>
+
+      <ModalBody>
+        <Form onSubmit={handleSubmit}>
+          <ButtonGroup className="w-100 mb-3">
+            <InputGroup>
+              <InputGroupText>
+                <Icon icon="it-search" />
+              </InputGroupText>
+              <input type="text" placeholder="Search" className="form-control" autoFocus />
+            </InputGroup>
+            <Button type="submit" color="primary">
+              Search
+            </Button>
+          </ButtonGroup>
+        </Form>
+
+        <div className="pb-4">
+          {status === 'pending' ? (
+            <div className="text-center">
+              <Spinner active small />
+            </div>
+          ) : status === 'error' ? (
+            <div>
+              <Alert color="danger">
+                <strong>Error:</strong> {error || 'Unknown error'}
+              </Alert>
+            </div>
+          ) : status === 'fulfilled' ? (
+            !filteredSchemas.length ? (
+              <div>
+                <Alert color="warning">No results found</Alert>
+              </div>
+            ) : (
+              <List>
+                {filteredSchemas.map((schema) => (
+                  <ListItem key={schema.url} href="#" onClick={() => handleSelectUrl(schema.url)} className="py-3">
+                    <div>
+                      <span className="text">{schema.label}</span>
+                      <small className="text-muted">{schema.url}</small>
+                    </div>
+                    <Icon icon="it-chevron-right" title="Use schema" />
+                  </ListItem>
+                ))}
+              </List>
+            )
+          ) : null}
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-schema.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/common/oas-graph/graph-schema.tsx
@@ -184,7 +184,7 @@ export const GraphSchema = ({ specSelectors, editorActions }) => {
                 color: '#ffffff',
                 'text-wrap': 'wrap',
                 'text-max-width': '80px',
-                'text-overflow-wrap': 'break-word',
+                'text-overflow-wrap': 'whitespace',
               },
             },
             {

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-rdf-ontologies-resolver.ts
@@ -1,3 +1,4 @@
+import { useConfiguration } from '../../configuration';
 import { AsyncState } from '../models';
 import { isUri } from '../utils';
 import { useSparqlQuery } from './use-sparql';
@@ -12,6 +13,7 @@ export interface RDFProperty {
 }
 
 export function useRDFPropertyResolver(fieldUri: string | undefined): AsyncState<RDFProperty> {
+  const { sparqlUrl } = useConfiguration();
   const {
     data: sparqlData,
     status: sparqlStatus,
@@ -54,7 +56,7 @@ export function useRDFPropertyResolver(fieldUri: string | undefined): AsyncState
       }
     }
   `,
-    { skip: !fieldUri },
+    { sparqlUrl: sparqlUrl!, skip: !fieldUri },
   );
 
   const content = sparqlData?.results?.bindings?.[0]
@@ -79,6 +81,7 @@ export function useRDFPropertyResolver(fieldUri: string | undefined): AsyncState
   This hook resolves the class hierarchy tree, returning parent-child relationships.
 */
 export function useRDFClassTreeResolver(classUri: string | undefined): AsyncState<{ parent: string; child: string }[]> {
+  const { sparqlUrl } = useConfiguration();
   const { data, status, error } = useSparqlQuery(
     `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -95,7 +98,7 @@ export function useRDFClassTreeResolver(classUri: string | undefined): AsyncStat
       FILTER( !isBlank(?child) && !isBlank(?parent) && ?child != ?parent)
     }
   `,
-    { skip: !classUri || !isUri(classUri) },
+    { sparqlUrl: sparqlUrl!, skip: !classUri || !isUri(classUri) },
   );
 
   const items = data?.results?.bindings?.map((binding: any) =>
@@ -110,6 +113,7 @@ export function useRDFClassTreeResolver(classUri: string | undefined): AsyncStat
 }
 
 export function useRDFClassResolver(classUri: string | undefined) {
+  const { sparqlUrl } = useConfiguration();
   const {
     data: sparqlData,
     status: sparqlStatus,
@@ -150,7 +154,7 @@ export function useRDFClassResolver(classUri: string | undefined) {
 
     }
   `,
-    { skip: !classUri || !isUri(classUri) },
+    { sparqlUrl: sparqlUrl!, skip: !classUri || !isUri(classUri) },
   );
 
   const content = sparqlData?.results?.bindings
@@ -182,6 +186,7 @@ export interface RDFClassProperties {
   controlledVocabulary: string | undefined;
 }
 export function useRDFClassPropertiesResolver(classUri: string | undefined) {
+  const { sparqlUrl } = useConfiguration();
   const { data: sparqlData, status: sparqlStatus } = useSparqlQuery(
     `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -238,7 +243,7 @@ export function useRDFClassPropertiesResolver(classUri: string | undefined) {
 
     }
   `,
-    { skip: !classUri },
+    { sparqlUrl: sparqlUrl!, skip: !classUri },
   );
 
   const content = sparqlData?.results?.bindings
@@ -268,6 +273,7 @@ export interface RDFClassVocabularies {
   api?: string;
 }
 export function useRDFClassVocabulariesResolver(classUri: string | undefined): AsyncState<RDFClassVocabularies[]> {
+  const { sparqlUrl } = useConfiguration();
   const {
     data: sparqlData,
     status: sparqlStatus,
@@ -319,7 +325,7 @@ SELECT DISTINCT
   }
 }
   `,
-    { skip: !classUri },
+    { sparqlUrl: sparqlUrl!, skip: !classUri },
   );
 
   const content = sparqlData?.results?.bindings

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-sparql.spec.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-sparql.spec.ts
@@ -1,19 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as configuration from '../../configuration';
-import { useSparqlQuery } from './use-sparql';
+import { describe, expect, it, vi } from 'vitest';
+import { SparqlQueryOptions, useSparqlQuery } from './use-sparql';
 
 describe('useSparqlQuery', () => {
-  beforeEach(() => {
-    vi.spyOn(configuration, 'useConfiguration').mockReturnValue({ sparqlUrl: 'https://sparql.com' });
-  });
-
   it('should fetch again if query changes', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response(JSON.stringify({ foo: 'bar' })))
       .mockResolvedValueOnce(new Response(JSON.stringify({ foo: 'baz' })));
-    const { result, rerender } = renderHook((query: string = 'testrequest') => useSparqlQuery(query));
+    const { result, rerender } = renderHook((query: string = 'testrequest') =>
+      useSparqlQuery(query, { sparqlUrl: 'https://sparql.com' }),
+    );
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
     rerender('anothertestrequest');
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
@@ -22,7 +19,7 @@ describe('useSparqlQuery', () => {
 
   it('should avoid refetch if query not changed', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ foo: 'bar' })));
-    const { result, rerender } = renderHook(() => useSparqlQuery('testrequest'));
+    const { result, rerender } = renderHook(() => useSparqlQuery('testrequest', { sparqlUrl: 'https://sparql.com' }));
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
     rerender();
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
@@ -31,14 +28,43 @@ describe('useSparqlQuery', () => {
 
   it('should trim whitespaces in sparqlUrl', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ foo: 'bar' })));
-    const { result } = renderHook(() => useSparqlQuery(' testrequest '));
+    const { result } = renderHook(() => useSparqlQuery(' testrequest ', { sparqlUrl: 'https://sparql.com' }));
     await waitFor(() => expect(result.current.status).toBe('fulfilled'));
     expect(fetchSpy).toHaveBeenCalledWith('https://sparql.com?format=json&query=%20testrequest%20', expect.anything());
   });
 
   it('should skip if option is provided', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ foo: 'bar' })));
-    renderHook(() => useSparqlQuery('testrequest', { skip: true }));
+    renderHook(() => useSparqlQuery('testrequest', { sparqlUrl: 'https://sparql.com', skip: true }));
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should discard fetch results if query changes', async () => {
+    let resolvePromise: any;
+    let fetchPromise: Promise<Response>;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() => {
+      fetchPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      return fetchPromise;
+    });
+
+    const options: SparqlQueryOptions = { sparqlUrl: 'https://sparql.com' };
+
+    const { result, rerender } = renderHook((props: [string, SparqlQueryOptions]) => useSparqlQuery(...props), {
+      initialProps: ['query1', options],
+    });
+    expect(result.current.status).toBe('pending');
+    await waitFor(() => expect(fetchPromise).toBeDefined());
+
+    rerender(['query2', { ...options, skip: true }]); // Update query in order to expect "idle" status and no results discarding fetch results
+    expect(result.current.status).toBe('idle');
+
+    resolvePromise(new Response(JSON.stringify({ foo: 'bar' })));
+
+    await waitFor(() => expect(result.current.status).toBe('idle'));
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-sparql.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-sparql.ts
@@ -1,42 +1,54 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useConfiguration } from '../../configuration';
+import { useEffect, useState } from 'react';
 import { AsyncState } from '../models';
 
-interface SparqlQueryOptions {
+export interface SparqlQueryOptions {
+  sparqlUrl: string;
   skip?: boolean;
   format?: string;
 }
 
-export function useSparqlQuery<T = any>(query: string, options?: SparqlQueryOptions) {
-  const { sparqlUrl } = useConfiguration();
+export function useSparqlQuery<T = any>(query: string, options: SparqlQueryOptions) {
   const [state, setState] = useState<AsyncState<T>>({ status: 'idle' });
-
-  const callback = useCallback(async () => {
-    try {
-      if (options?.skip) {
-        return;
-      }
-      setState({ status: 'pending' });
-      const endpoint = `${sparqlUrl?.trim()}?format=${encodeURIComponent(options?.format || 'json')}&query=${encodeURIComponent(query)}`;
-      const response = await fetch(endpoint, { cache: 'force-cache' });
-      if (!response.ok) {
-        throw new Error(response.statusText);
-      }
-      const data = await response.json();
-      setState({ status: 'fulfilled', data });
-    } catch (e) {
-      console.error(e);
-      setState({ status: 'error', error: e?.message || e || 'Unknown error' });
-    }
-  }, [query, options?.skip]);
 
   useEffect(() => {
     setState({ status: 'idle' }); // Se cambia la query resetto lo status
   }, [query]);
 
   useEffect(() => {
-    callback();
-  }, [callback]);
+    let isCancelled = false;
+
+    const runQuery = async () => {
+      try {
+        if (options.skip) {
+          return;
+        }
+
+        setState({ status: 'pending' });
+        const endpoint = `${options.sparqlUrl.trim()}?format=${encodeURIComponent(options.format || 'json')}&query=${encodeURIComponent(query)}`;
+        const response = await fetch(endpoint, { cache: 'force-cache' });
+        if (!response.ok) {
+          throw new Error(response.statusText);
+        }
+        if (isCancelled) {
+          return;
+        }
+        const data = await response.json();
+        setState({ status: 'fulfilled', data });
+      } catch (e) {
+        if (isCancelled) {
+          return;
+        }
+        console.error(e);
+        setState({ status: 'error', error: e?.message || e || 'Unknown error' });
+      }
+    };
+
+    runQuery();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [query, options.skip, options.sparqlUrl, options.format]);
 
   return state;
 }

--- a/packages/schema-editor/src/plugins/json-schema-5/hooks/use-vocabularies-query.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/hooks/use-vocabularies-query.ts
@@ -1,7 +1,9 @@
+import { useConfiguration } from '../../configuration';
 import { AsyncState } from '../models';
 import { useSparqlQuery } from './use-sparql';
 
 export function useVocabulariesQuery(): AsyncState<any> {
+  const { sparqlUrl } = useConfiguration();
   const { data, status, error } = useSparqlQuery<any>(
     `
     PREFIX ndc: <https://w3id.org/italia/onto/NDC/>
@@ -42,6 +44,7 @@ export function useVocabulariesQuery(): AsyncState<any> {
     LIMIT 7
   `,
     {
+      sparqlUrl: sparqlUrl!,
       format: 'application/ld+json',
     },
   );
@@ -57,6 +60,7 @@ export function useVocabularyQuery(vocabulary_uri: string): AsyncState<any> {
   // Fetch vocabulary data in JSON-LD format
   //   LIMIT is in triples, not in resources, so
   //   you need to count resources * entries.
+  const { sparqlUrl } = useConfiguration();
   const { data, status, error } = useSparqlQuery<any>(
     `
     PREFIX ndc: <https://w3id.org/italia/onto/NDC/>
@@ -89,6 +93,7 @@ export function useVocabularyQuery(vocabulary_uri: string): AsyncState<any> {
     LIMIT 100
   `,
     {
+      sparqlUrl: sparqlUrl!,
       format: 'application/ld+json',
     },
   );

--- a/packages/schema-editor/src/plugins/json-schema-5/index.ts
+++ b/packages/schema-editor/src/plugins/json-schema-5/index.ts
@@ -11,6 +11,7 @@ import { ModelsBreadcrumb } from './components/models-breadcrumb';
 import { ObjectModel } from './components/object-model';
 import { PrimitiveModel } from './components/primitive-model';
 
+export * from './hooks';
 export * from './utils';
 
 export const JSONSchema5Plugin = () => ({


### PR DESCRIPTION
## This PR:

Fix: #80

When:

- `CTRL+SHIFT+P` keyboard shortcut is pressed

Then:

- show a search schemas modal to search for openapi yaml schemas.

The modal:

- Allows filtering the results via search input.
- Allows using those schemas in the editor,

## Notes

- updates the usesparqlquery hook to expect external sparqlUrl param in order to be reused as external hook (not bound to inner config only)
- fixes the usesparqlquery to discard previous async results when a subsequent callback is performed