### PR TITLE
Fix: #215. API container not starting due to pnpm corepack

### DIFF
--- a/.changeset/sparkly-doors-thank.md
+++ b/.changeset/sparkly-doors-thank.md
@@ -1,0 +1,5 @@
+---
+'api': patch
+---
+
+Updated docker run command to avoid pnpm version

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER 1000
 
 ENV NODE_ENV=production
 ENV HOME=/home/node
-CMD ["pnpm","start:prod"]
+CMD ["node","dist/main"]
 
 # checkov:skip=CKV_DOCKER_2
 FROM nginx AS example


### PR DESCRIPTION
# This PR:

Updates the docker run command to directly use node avoiding using any package manager.